### PR TITLE
Add pyproject and installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
 # Health-Lab
+
+This project contains the Health-Lab codebase.
+
+## Installing Dependencies
+
+Health-Lab uses [Poetry](https://python-poetry.org/) for dependency management. Install Poetry and then run the following command to install all required packages:
+
+```bash
+poetry install
+```
+
+This will install the main dependencies (`fastapi`, `pydantic`) along with development tools for running tests (`pytest`, `pytest-asyncio`).
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,19 @@
+[tool.poetry]
+name = "health-lab"
+version = "0.1.0"
+description = "Health-Lab project"
+authors = []
+
+[tool.poetry.dependencies]
+python = "^3.10"
+fastapi = "*"
+pydantic = "*"
+
+[tool.poetry.group.dev.dependencies]
+pytest = "^7.0"
+pytest-asyncio = "^0.21"
+
+[build-system]
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"
+


### PR DESCRIPTION
## Summary
- set up Poetry `pyproject.toml` with FastAPI, Pydantic and test deps
- document installing dependencies with Poetry in the README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687a743a09d88332aecbba2a9cfbd07b